### PR TITLE
Add project overview README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Evacuation Planning Research
+
+This repository collects code and documents for studying large-scale
+evacuation planning. A C++ simulator models traffic flow and agent
+behavior across road networks described in a custom scenario language,
+Slang.
+
+## Directory Map
+
+- Simulation/ - C++ simulation engine and experiment assets.
+- Slang/ - LaTeX sources for the Slang scenario language reference.
+- Paper/ - Drafts and figures for the main research paper.
+- Papers/ - Reference literature.
+- Notes/ - Project notes.
+
+## Build
+
+The simulator depends on g++ (C++11), flex, bison, pthreads, libm and
+libfl. Compile the engine and produce the `evac` binary:
+
+```bash
+cd Simulation
+make
+```
+
+## Run
+
+Invoke the simulator with a scenario:
+
+```bash
+./evac path/to/scenario.slang
+```
+
+Sample scenarios and datasets reside in `Simulation/boise`. For example:
+
+```bash
+./evac boise/boise.slang
+```
+
+Results from prior experiments and plotting scripts are in
+`Simulation/results`. Other scenario sets, such as
+`Simulation/topologyTestProbSet`, support additional experiments.
+


### PR DESCRIPTION
## Summary
- introduce repository with project overview and directory map
- document build process for `evac` simulator
- show how to run scenarios and point to sample datasets

## Testing
- `cd Simulation && make` *(fails: src/edge.cpp:21:3: error: 'printf' was not declared in this scope)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a3fbd5c1dc832586b68c09a944856f